### PR TITLE
Replace HN links in comments with reader links

### DIFF
--- a/app/components/Comment.tsx
+++ b/app/components/Comment.tsx
@@ -1,5 +1,6 @@
 import { Box, chakra, Text } from "@chakra-ui/react";
 import { Item } from "~/utils/api.server";
+import { replaceHnLinksWithReader } from "~/utils/linkProcessing";
 
 export function Comment(
   props: {
@@ -79,7 +80,7 @@ export function Comment(
           as="div"
           fontFamily="serif"
           marginX={4}
-          dangerouslySetInnerHTML={{ __html: comment.text || "" }}
+          dangerouslySetInnerHTML={{ __html: replaceHnLinksWithReader(comment.text || "") }}
         />
         {children && <Box paddingX={2}>{children}</Box>}
       </Box>

--- a/app/utils/linkProcessing.ts
+++ b/app/utils/linkProcessing.ts
@@ -1,0 +1,12 @@
+export function replaceHnLinksWithReader(html: string): string {
+  if (!html) return html;
+  
+  // Replace HN item links with reader links
+  // Matches patterns like:
+  // - https://news.ycombinator.com/item?id=12345
+  // - http://news.ycombinator.com/item?id=12345
+  return html.replace(
+    /https?:\/\/news\.ycombinator\.com\/item\?id=(\d+)/g,
+    'https://hn.joncallahan.com/item/$1'
+  );
+}


### PR DESCRIPTION
## Summary
- Replace `news.ycombinator.com/item?id=xxx` links in comment text with `hn.joncallahan.com/item/xxx`
- Keep users within the reader when they click on HN references in comments
- Added utility function for link processing and updated Comment component

## Test plan
- [x] Build completes successfully
- [x] Link replacement function correctly transforms HN URLs
- [ ] Manual testing: Find a comment with HN links and verify they redirect to reader

🤖 Generated with [Claude Code](https://claude.ai/code)