### PR TITLE
Fix tweet preview text fitting on mobile

### DIFF
--- a/app/components/HeroImage.tsx
+++ b/app/components/HeroImage.tsx
@@ -53,10 +53,10 @@ function TweetEmbed({ tweet }: { tweet: Tweet }) {
     >
       <Flex direction="column" justify={"center"} height="full" px={4} gap={[0.5, 1]}>
         <Flex alignItems="center" gap="2">
-          <Avatar src={avatar} name={handle} size="sm">
+          <Avatar src={avatar} name={handle} size={["xs", "sm"]}>
             {isVerified && <AvatarBadge boxSize="1em" bgColor="twitter.500" />}
           </Avatar>
-          <Text fontWeight="bold">{handle}</Text>
+          <Text fontWeight="bold" fontSize={["xs", "md"]}>{handle}</Text>
         </Flex>
         <Heading
           size={["xs", "md"]}
@@ -101,10 +101,10 @@ function TweetEmbed({ tweet }: { tweet: Tweet }) {
           </Flex>
         </Flex>
         <Flex alignItems="center" gap="2">
-          <Icon viewBox="0 0 20 20" boxSize={4} fill="twitter.600">
+          <Icon viewBox="0 0 20 20" boxSize={[3, 4]} fill="twitter.600">
             <path d="M6.29 18.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0020 3.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.073 4.073 0 01.8 7.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 010 16.407a11.615 11.615 0 006.29 1.84" />
           </Icon>
-          <Text>{friendlyDate}</Text>
+          <Text fontSize={["xs", "md"]}>{friendlyDate}</Text>
         </Flex>
       </Flex>
     </Box>

--- a/app/components/HeroImage.tsx
+++ b/app/components/HeroImage.tsx
@@ -51,18 +51,23 @@ function TweetEmbed({ tweet }: { tweet: Tweet }) {
       bg="white"
       color="twitter.600"
     >
-      <Flex direction="column" justify={"center"} height="full" px={4} gap="1">
+      <Flex direction="column" justify={"center"} height="full" px={4} gap={[0.5, 1]}>
         <Flex alignItems="center" gap="2">
           <Avatar src={avatar} name={handle} size="sm">
             {isVerified && <AvatarBadge boxSize="1em" bgColor="twitter.500" />}
           </Avatar>
           <Text fontWeight="bold">{handle}</Text>
         </Flex>
-        <Heading size="md" lineHeight="shorter">
+        <Heading
+          size={["xs", "md"]}
+          lineHeight="shorter"
+          noOfLines={[3, 4]}
+          overflow="hidden"
+        >
           {friendlyText}
         </Heading>
         {hasImage && (
-          <Flex alignItems="center" gap="2">
+          <Flex alignItems="center" gap="2" display={["none", "flex"]}>
             <Icon
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
@@ -77,7 +82,7 @@ function TweetEmbed({ tweet }: { tweet: Tweet }) {
             <Text fontSize="sm">Photo attached</Text>
           </Flex>
         )}
-        <Flex alignItems="center" gap="2">
+        <Flex alignItems="center" gap="2" display={["none", "flex"]}>
           <Flex alignItems="center" gap="2">
             <Icon viewBox="0 0 20 20" fill="red.500" boxSize={5}>
               <path d="M9.653 16.915l-.005-.003-.019-.01a20.759 20.759 0 01-1.162-.682 22.045 22.045 0 01-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 018-2.828A4.5 4.5 0 0118 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 01-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 01-.69.001l-.002-.001z" />

--- a/app/components/HeroImage.tsx
+++ b/app/components/HeroImage.tsx
@@ -59,7 +59,7 @@ function TweetEmbed({ tweet }: { tweet: Tweet }) {
           <Text fontWeight="bold" fontSize={["xs", "md"]}>{handle}</Text>
         </Flex>
         <Heading
-          size={["xs", "md"]}
+          size={["sm", "md"]}
           lineHeight="shorter"
           noOfLines={[3, 4]}
           overflow="hidden"


### PR DESCRIPTION
## Summary
Improves how longer tweets fit in the card on mobile devices.

## Changes
- Use smaller text size (xs) on mobile for tweet content
- Allow 3 lines of text on mobile instead of 2
- Reduce gap between elements on mobile
- Hide photo indicator and engagement stats on mobile to save space